### PR TITLE
fix workflow filename in README.md

### DIFF
--- a/ch5/github-actions/README.md
+++ b/ch5/github-actions/README.md
@@ -6,7 +6,7 @@ This folder contains:
 * `infra-tests.yml`: A GitHub Actions workflow to run the automated tests for an OpenTofu  module.
 * `tofu-plan.yml`: A GitHub Actions workflow that runs on PRs that modify an OpenTofu module. This workflow runs 
   `tofu plan` on the module and posts the plan output as a comment in the PR.
-* `tofu-plan.yml`: A GitHub Actions workflow that runs on merged PRs that modify an OpenTofu module. This workflow runs 
+* `tofu-apply.yml`: A GitHub Actions workflow that runs on merged PRs that modify an OpenTofu module. This workflow runs 
   `tofu apply` on the module and posts the apply output as a comment in the PR.
 
 For more information, see Chapter 5, "How to Set Up Continuous Integration (CI) and Continuous Delivery (CD)", of 


### PR DESCRIPTION
Changes `tofu-plan.yml` to `tofu-apply.yml` to match to the correct workflow file.