### PR TITLE
AWS Lambda: Add permissions for public access

### DIFF
--- a/ch3/tofu/modules/lambda/main.tf
+++ b/ch3/tofu/modules/lambda/main.tf
@@ -61,3 +61,22 @@ resource "aws_lambda_function_url" "url" {
   function_name      = aws_lambda_function.function.function_name
   authorization_type = "NONE"
 }
+
+resource "aws_lambda_permission" "allow_invoke_function" {
+  count = var.create_url ? 1 : 0
+
+  function_name = aws_lambda_function.function.function_name
+  statement_id  = "AllowInvokeFunction"
+  action        = "lambda:InvokeFunction"
+  principal     = "*"
+}
+
+resource "aws_lambda_permission" "allow_invoke_function_url" {
+  count = var.create_url ? 1 : 0
+
+  function_name          = aws_lambda_function.function.function_name
+  statement_id           = "AllowInvokeFunctionUrl"
+  action                 = "lambda:InvokeFunctionUrl"
+  principal              = "*"
+  function_url_auth_type = "NONE"
+}


### PR DESCRIPTION
# Chapter 3 > Serverless Orchestration > Create a Lambda Function URL > Permissions issue

AWS updated Lambda security and now (since 2025/10) we need to add 2 permissions so we can invoke the Lambda functions via public URL.

## Current situation:

When you try to invoke the Lambda function you get the response:

```
{
  "Message": "Forbidden. For troubleshooting Function URL authorization issues, see: https://docs.aws.amazon.com/lambda/latest/dg/urls-auth.html"
}
```

AWS documentation says:

```
Note

Starting in October 2025, new function URLs will require both lambda:InvokeFunctionUrl and lambda:InvokeFunction permissions.
```

## Fix:

Add 2 required permissions as per AWS documentation.